### PR TITLE
Fixed path format.

### DIFF
--- a/2.3.4/Dockerfile
+++ b/2.3.4/Dockerfile
@@ -14,7 +14,7 @@ ENV WORKDIR_PATH=/app/user \
     # https://github.com/heroku/heroku-buildpack-ruby/blob/master/lib/language_pack/ruby.rb#L19
     BUNDLER_VERSION=1.15.2
 
-ENV PATH=$WORKDIR_PATH/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:/app/heroku/ruby/node-$NODE_VERSION/bin:/app/heroku/ruby/ruby-$RUBY_VERSION/bin/$PATH \
+ENV PATH=$WORKDIR_PATH/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:/app/heroku/ruby/node-$NODE_VERSION/bin:/app/heroku/ruby/ruby-$RUBY_VERSION/bin/:${PATH} \
     # Bundler variables
     GEM_PATH=/app/heroku/ruby/bundle/ruby/$RUBY_VERSION \
     GEM_HOME=/app/heroku/ruby/bundle/ruby/$RUBY_VERSION \

--- a/2.3.7/Dockerfile
+++ b/2.3.7/Dockerfile
@@ -14,7 +14,7 @@ ENV WORKDIR_PATH=/app/user \
     # https://github.com/heroku/heroku-buildpack-ruby/blob/master/lib/language_pack/ruby.rb#L19
     BUNDLER_VERSION=1.15.2
 
-ENV PATH=$WORKDIR_PATH/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:/app/heroku/ruby/node-$NODE_VERSION/bin:/app/heroku/ruby/ruby-$RUBY_VERSION/bin/$PATH \
+ENV PATH=$WORKDIR_PATH/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:/app/heroku/ruby/node-$NODE_VERSION/bin:/app/heroku/ruby/ruby-$RUBY_VERSION/bin/:${PATH} \
     # Bundler variables
     GEM_PATH=/app/heroku/ruby/bundle/ruby/$RUBY_VERSION \
     GEM_HOME=/app/heroku/ruby/bundle/ruby/$RUBY_VERSION \

--- a/2.4.4/Dockerfile
+++ b/2.4.4/Dockerfile
@@ -14,7 +14,7 @@ ENV WORKDIR_PATH=/app/user \
     # https://github.com/heroku/heroku-buildpack-ruby/blob/master/lib/language_pack/ruby.rb#L19
     BUNDLER_VERSION=1.15.2
 
-ENV PATH=$WORKDIR_PATH/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:/app/heroku/ruby/node-$NODE_VERSION/bin:/app/heroku/ruby/ruby-$RUBY_VERSION/bin/$PATH \
+ENV PATH=$WORKDIR_PATH/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:/app/heroku/ruby/node-$NODE_VERSION/bin:/app/heroku/ruby/ruby-$RUBY_VERSION/bin/:${PATH} \
     # Bundler variables
     GEM_PATH=/app/heroku/ruby/bundle/ruby/$RUBY_VERSION \
     GEM_HOME=/app/heroku/ruby/bundle/ruby/$RUBY_VERSION \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -14,7 +14,7 @@ ENV WORKDIR_PATH=/app/user \
     # https://github.com/heroku/heroku-buildpack-ruby/blob/master/lib/language_pack/ruby.rb#L19
     BUNDLER_VERSION=%%BUNDLER_VERSION%%
 
-ENV PATH=$WORKDIR_PATH/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:/app/heroku/ruby/node-$NODE_VERSION/bin:/app/heroku/ruby/ruby-$RUBY_VERSION/bin/$PATH \
+ENV PATH=$WORKDIR_PATH/bin:/app/heroku/ruby/bundle/ruby/$RUBY_VERSION/bin:/app/heroku/ruby/node-$NODE_VERSION/bin:/app/heroku/ruby/ruby-$RUBY_VERSION/bin/:${PATH} \
     # Bundler variables
     GEM_PATH=/app/heroku/ruby/bundle/ruby/$RUBY_VERSION \
     GEM_HOME=/app/heroku/ruby/bundle/ruby/$RUBY_VERSION \


### PR DESCRIPTION
Running `which ruby` was returning /usr/bin/ruby instead of the version found in the /app directory due to a formatting error with the path that was set. This resolves that error.